### PR TITLE
Add reservation metadata with --note and --user flags

### DIFF
--- a/internal/cli/reserve.go
+++ b/internal/cli/reserve.go
@@ -59,8 +59,10 @@ automatically expire after the specified duration.`,
 		gpuIDs := viper.GetIntSlice("reserve.gpu-ids")
 		durationStr := viper.GetString("reserve.duration")
 		force := viper.GetBool("reserve.force")
+		note := viper.GetString("reserve.note")
+		customUser := viper.GetString("reserve.user")
 
-		return runReserve(cmd.Context(), gpuCount, gpuIDs, durationStr, force)
+		return runReserve(cmd.Context(), gpuCount, gpuIDs, durationStr, force, note, customUser)
 	},
 }
 
@@ -69,11 +71,13 @@ func init() {
 	reserveCmd.Flags().IntSliceP("gpu-ids", "G", nil, "Specific GPU IDs to reserve (comma-separated, e.g., 1,3,5)")
 	reserveCmd.Flags().StringP("duration", "d", "8h", "Duration to reserve GPUs (e.g., 30m, 2h, 1d)")
 	reserveCmd.Flags().BoolP("force", "f", false, "Force reservation even if GPU is in unreserved use")
+	reserveCmd.Flags().StringP("note", "n", "", "Optional note describing the reservation purpose")
+	reserveCmd.Flags().StringP("user", "u", "", "Custom user identifier (e.g., your name when using a shared account)")
 
 	rootCmd.AddCommand(reserveCmd)
 }
 
-func runReserve(ctx context.Context, gpuCount int, gpuIDs []int, durationStr string, force bool) error {
+func runReserve(ctx context.Context, gpuCount int, gpuIDs []int, durationStr string, force bool, note string, customUser string) error {
 	// If neither is specified, default to 1 GPU
 	if gpuCount == 0 && len(gpuIDs) == 0 {
 		gpuCount = 1
@@ -101,16 +105,24 @@ func runReserve(ctx context.Context, gpuCount int, gpuIDs []int, durationStr str
 	// Create allocation engine
 	engine := gpu.NewAllocationEngine(client, config)
 
+	// Get actual OS user and determine display user
+	actualUser := getCurrentUser()
+	displayUser := actualUser
+	if customUser != "" {
+		displayUser = customUser
+	}
+
 	// Create allocation request
-	user := getCurrentUser()
 	expiryTime := time.Now().Add(duration)
 	request := &types.AllocationRequest{
 		GPUCount:        gpuCount,
 		GPUIDs:          gpuIDs,
-		User:            user,
+		User:            displayUser,
+		ActualUser:      actualUser,
 		ReservationType: types.ReservationTypeManual,
 		ExpiryTime:      &expiryTime,
 		Force:           force,
+		Note:            note,
 	}
 
 	// Allocate GPUs

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -154,7 +154,7 @@ func TestRunRun_Validation(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			err := runRun(ctx, tt.gpuCount, nil, "", tt.command)
+			err := runRun(ctx, tt.gpuCount, nil, "", "", "", tt.command)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -377,6 +377,7 @@ func convertJSONToStatusInfo(j JSONGPUStatus) gpu.GPUStatusInfo {
 		GPUID:  j.GPUID,
 		Status: j.Status,
 		User:   j.User,
+		Note:   j.Note,
 	}
 
 	// Parse duration if present
@@ -533,13 +534,13 @@ func displayGPUStatusTable(statuses []gpu.GPUStatusInfo) {
 		t.AppendHeader(table.Row{
 			FormatHeader("GPU"), FormatHeader("STATUS"), FormatHeader("USER"),
 			FormatHeader("DURATION"), FormatHeader("TYPE"), FormatHeader("DETAILS"),
-			FormatHeader("VALIDATION"), FormatHeader("MODEL"),
+			FormatHeader("VALIDATION"), FormatHeader("MODEL"), FormatHeader("NOTE"),
 		})
 	} else {
 		t.AppendHeader(table.Row{
 			FormatHeader("GPU"), FormatHeader("STATUS"), FormatHeader("USER"),
 			FormatHeader("DURATION"), FormatHeader("TYPE"), FormatHeader("DETAILS"),
-			FormatHeader("VALIDATION"),
+			FormatHeader("VALIDATION"), FormatHeader("NOTE"),
 		})
 	}
 
@@ -576,12 +577,12 @@ func addGPUStatusRow(t table.Writer, status gpu.GPUStatusInfo, includeModel bool
 		if includeModel {
 			t.AppendRow(table.Row{
 				gpuID, FormatStatus("AVAILABLE"), FormatDim("-"), FormatDim("-"), FormatDim("-"),
-				details, FormatDim(validation), model,
+				details, FormatDim(validation), model, FormatDim("-"),
 			})
 		} else {
 			t.AppendRow(table.Row{
 				gpuID, FormatStatus("AVAILABLE"), FormatDim("-"), FormatDim("-"), FormatDim("-"),
-				details, FormatDim(validation),
+				details, FormatDim(validation), FormatDim("-"),
 			})
 		}
 
@@ -616,13 +617,19 @@ func addGPUStatusRow(t table.Writer, status gpu.GPUStatusInfo, includeModel bool
 			model = status.ModelInfo.Model
 		}
 
+		// Format note
+		note := "-"
+		if status.Note != "" {
+			note = status.Note
+		}
+
 		if includeModel {
 			t.AppendRow(table.Row{
-				gpuID, FormatStatus("IN_USE"), user, duration, reservationType, details, FormatDim(validation), model,
+				gpuID, FormatStatus("IN_USE"), user, duration, reservationType, details, FormatDim(validation), model, note,
 			})
 		} else {
 			t.AppendRow(table.Row{
-				gpuID, FormatStatus("IN_USE"), user, duration, reservationType, details, FormatDim(validation),
+				gpuID, FormatStatus("IN_USE"), user, duration, reservationType, details, FormatDim(validation), note,
 			})
 		}
 
@@ -639,12 +646,12 @@ func addGPUStatusRow(t table.Writer, status gpu.GPUStatusInfo, includeModel bool
 		if includeModel {
 			t.AppendRow(table.Row{
 				gpuID, FormatStatus("UNRESERVED"), userList, FormatDim("-"), FormatDim("-"),
-				details, FormatDim("-"), model,
+				details, FormatDim("-"), model, FormatDim("-"),
 			})
 		} else {
 			t.AppendRow(table.Row{
 				gpuID, FormatStatus("UNRESERVED"), userList, FormatDim("-"), FormatDim("-"),
-				details, FormatDim("-"),
+				details, FormatDim("-"), FormatDim("-"),
 			})
 		}
 
@@ -652,12 +659,12 @@ func addGPUStatusRow(t table.Writer, status gpu.GPUStatusInfo, includeModel bool
 		if includeModel {
 			t.AppendRow(table.Row{
 				gpuID, FormatStatus("ERROR"), FormatDim("-"), FormatDim("-"), FormatDim("-"),
-				status.Error, FormatDim("-"), FormatDim("-"),
+				status.Error, FormatDim("-"), FormatDim("-"), FormatDim("-"),
 			})
 		} else {
 			t.AppendRow(table.Row{
 				gpuID, FormatStatus("ERROR"), FormatDim("-"), FormatDim("-"), FormatDim("-"),
-				status.Error, FormatDim("-"),
+				status.Error, FormatDim("-"), FormatDim("-"),
 			})
 		}
 
@@ -665,12 +672,12 @@ func addGPUStatusRow(t table.Writer, status gpu.GPUStatusInfo, includeModel bool
 		if includeModel {
 			t.AppendRow(table.Row{
 				gpuID, "UNKNOWN", FormatDim("-"), FormatDim("-"), FormatDim("-"),
-				"unknown status", FormatDim("-"), FormatDim("-"),
+				"unknown status", FormatDim("-"), FormatDim("-"), FormatDim("-"),
 			})
 		} else {
 			t.AppendRow(table.Row{
 				gpuID, "UNKNOWN", FormatDim("-"), FormatDim("-"), FormatDim("-"),
-				"unknown status", FormatDim("-"),
+				"unknown status", FormatDim("-"), FormatDim("-"),
 			})
 		}
 	}
@@ -683,6 +690,7 @@ type JSONGPUStatus struct {
 	User            string         `json:"user,omitempty"`
 	Duration        string         `json:"duration,omitempty"`
 	ReservationType string         `json:"type,omitempty"`
+	Note            string         `json:"note,omitempty"`
 	Details         string         `json:"details,omitempty"`
 	ValidationInfo  string         `json:"validation,omitempty"`
 	ModelInfo       *JSONModelInfo `json:"model,omitempty"`
@@ -721,6 +729,10 @@ func displayGPUStatusJSON(statuses []gpu.GPUStatusInfo) error {
 
 		if status.ReservationType != "" {
 			jsonStatus.ReservationType = strings.ToUpper(status.ReservationType)
+		}
+
+		if status.Note != "" {
+			jsonStatus.Note = status.Note
 		}
 
 		// Add details based on status type

--- a/internal/gpu/validation.go
+++ b/internal/gpu/validation.go
@@ -16,12 +16,16 @@ import (
 // getProcessOwner determines the owner of a process
 func getProcessOwner(pid int) (string, error) {
 	// Try /proc filesystem first
-	if user, err := getProcessOwnerFromProc(pid); err == nil {
-		return user, nil
+	user, err := getProcessOwnerFromProc(pid)
+	if err != nil {
+		// Fallback to ps command
+		user, err = getProcessOwnerFromPS(pid)
+		if err != nil {
+			return "", err
+		}
 	}
 
-	// Fallback to ps command
-	return getProcessOwnerFromPS(pid)
+	return user, nil
 }
 
 // GetProcessOwner is the exported version for tests

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -8,12 +8,14 @@ import (
 
 // GPUState represents the state of a GPU in Redis
 type GPUState struct {
-	User          string       `json:"user,omitempty"`
+	User          string       `json:"user,omitempty"`        // Display name (custom user if provided, otherwise OS user)
+	ActualUser    string       `json:"actual_user,omitempty"` // Actual OS account name
 	StartTime     FlexibleTime `json:"start_time,omitempty"`
 	LastHeartbeat FlexibleTime `json:"last_heartbeat,omitempty"`
 	Type          string       `json:"type,omitempty"` // "run" or "manual"
 	ExpiryTime    FlexibleTime `json:"expiry_time,omitempty"`
 	LastReleased  FlexibleTime `json:"last_released,omitempty"`
+	Note          string       `json:"note,omitempty"`
 }
 
 // FlexibleTime handles both Unix timestamps and RFC3339 time strings
@@ -85,12 +87,14 @@ type GPUProcessInfo struct {
 
 // AllocationRequest represents a request to allocate GPUs
 type AllocationRequest struct {
-	GPUCount        int   // Number of GPUs to allocate (ignored if GPUIDs is specified)
-	GPUIDs          []int // Specific GPU IDs to allocate (mutually exclusive with GPUCount)
-	User            string
+	GPUCount        int    // Number of GPUs to allocate (ignored if GPUIDs is specified)
+	GPUIDs          []int  // Specific GPU IDs to allocate (mutually exclusive with GPUCount)
+	User            string // Display name (custom user if --user flag provided)
+	ActualUser      string // Actual OS account name
 	ReservationType string
 	ExpiryTime      *time.Time
-	Force           bool // If true, allow reserving GPUs that are in unreserved use
+	Force           bool   // If true, allow reserving GPUs that are in unreserved use
+	Note            string // Optional note describing the reservation purpose
 }
 
 // Validate checks if the allocation request is valid


### PR DESCRIPTION
## Summary
- Add `--note` flag to `reserve` and `run` commands for documenting GPU reservation purpose
- Add `--user` flag to `reserve` and `run` commands for self-identification on shared accounts
- Track both actual OS user and custom display user separately
- Update status display to show "actual_user (display_user)" when different
- Add NOTE column to status table and JSON output

## Use Cases

**Shared Account Identification**: When multiple researchers use a shared service account, the `--user` flag allows them to identify themselves:
```bash
canhazgpu run --user "Jane Doe" --gpus 2 -- python train.py
```

**Reservation Documentation**: The `--note` flag helps others understand what GPUs are being used for:
```bash
canhazgpu reserve --gpus 4 --duration 8h --note "Training ResNet-50 on ImageNet"
```

**Combined Usage**: Both flags work together for maximum context:
```bash
canhazgpu run --user "Jane" --note "Fine-tuning LLaMA-2-7B" --gpus 4 -- python finetune.py
```

## Example output

**When a user has identified themselves**:

<img width="1460" height="258" alt="image" src="https://github.com/user-attachments/assets/4160da7c-beb0-4fd3-a678-0d4587385a32" />

**When a user leaves a note**:

<img width="1716" height="275" alt="image" src="https://github.com/user-attachments/assets/64b16b84-b8d5-40f9-a0cf-cff716a11241" />


## Changes
- Added `--note/-n` flag to reserve and run commands
- Added `--user/-u` flag to reserve and run commands
- Added `Note` field to `GPUState` and `AllocationRequest` types
- Added `ActualUser` field to track OS account separately from display name
- Updated status display with NOTE column and dual-user format
- Modified Redis Lua scripts to handle new metadata fields
- Updated tests to match new function signatures

## Test Plan
- [x] All existing tests pass
- [x] Code formatting verified with `make fmt`
- [x] Test coverage for new function signatures
- [x] Manual testing with both flags individually and combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)