### PR TITLE
Kill process when GPU reservation is lost

### DIFF
--- a/internal/cli/supervisor.go
+++ b/internal/cli/supervisor.go
@@ -117,53 +117,49 @@ func runSupervisor(ctx context.Context, gpuIDs []int, user string, pid int, time
 	for {
 		select {
 		case <-ctx.Done():
-			// Context cancelled, exit gracefully
+			return nil
+
+		case <-heartbeat.ReservationLost():
+			fmt.Fprintf(os.Stderr, "supervisor: GPU reservation lost, terminating process %d\n", pid)
+			gracefulKill(pid)
 			return nil
 
 		case <-timeoutChan:
-			// Timeout reached - attempt graceful shutdown
 			fmt.Fprintf(os.Stderr, "supervisor: timeout reached after %s, sending SIGINT to process %d\n",
 				utils.FormatDuration(timeout), pid)
-
-			// Send SIGINT for graceful shutdown
-			if err := syscall.Kill(pid, syscall.SIGINT); err != nil {
-				// Process may have already exited
-				if !isProcessRunning(pid) {
-					return nil
-				}
-				fmt.Fprintf(os.Stderr, "supervisor: failed to send SIGINT: %v\n", err)
-			}
-
-			// Wait grace period
-			gracePeriod := 30 * time.Second
-			fmt.Fprintf(os.Stderr, "supervisor: waiting %s for graceful shutdown...\n", gracePeriod)
-			time.Sleep(gracePeriod)
-
-			// Check if process is still running
-			if isProcessRunning(pid) {
-				fmt.Fprintf(os.Stderr, "supervisor: grace period expired, sending SIGKILL to process %d\n", pid)
-				if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
-					fmt.Fprintf(os.Stderr, "supervisor: failed to send SIGKILL: %v\n", err)
-				}
-			}
-
-			// Process should be dead now, exit
+			gracefulKill(pid)
 			return nil
 
 		case <-ticker.C:
-			// Check if process is still running
 			if !isProcessRunning(pid) {
-				// Process has exited, we're done
-				// The deferred heartbeat.Stop() will release GPUs
 				return nil
 			}
 		}
 	}
 }
 
-// isProcessRunning checks if a process with the given PID is still running
+// gracefulKill sends SIGINT, waits a grace period, then SIGKILL if still running.
+func gracefulKill(pid int) {
+	if err := syscall.Kill(pid, syscall.SIGINT); err != nil {
+		if !isProcessRunning(pid) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "supervisor: failed to send SIGINT: %v\n", err)
+	}
+
+	gracePeriod := 30 * time.Second
+	fmt.Fprintf(os.Stderr, "supervisor: waiting %s for graceful shutdown...\n", gracePeriod)
+	time.Sleep(gracePeriod)
+
+	if isProcessRunning(pid) {
+		fmt.Fprintf(os.Stderr, "supervisor: grace period expired, sending SIGKILL to process %d\n", pid)
+		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+			fmt.Fprintf(os.Stderr, "supervisor: failed to send SIGKILL: %v\n", err)
+		}
+	}
+}
+
 func isProcessRunning(pid int) bool {
-	// Sending signal 0 checks if process exists without actually sending a signal
 	err := syscall.Kill(pid, 0)
 	return err == nil
 }

--- a/internal/gpu/heartbeat.go
+++ b/internal/gpu/heartbeat.go
@@ -2,8 +2,10 @@ package gpu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/russellb/canhazgpu/internal/redis_client"
@@ -13,26 +15,33 @@ import (
 // consecutiveFailures tracks heartbeat failures to trigger reconnection
 const maxFailuresBeforeReconnect = 2
 
+var ErrReservationLost = errors.New("GPU reservation lost")
+
 type HeartbeatManager struct {
-	client              *redis_client.Client
-	allocatedGPUs       []int
-	user                string
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	done                chan struct{}
-	consecutiveFailures int
+	client                *redis_client.Client
+	allocatedGPUs         []int
+	user                  string
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	done                  chan struct{}
+	reservationLost       chan struct{}
+	reservationLostOnce   sync.Once
+	consecutiveFailures   int
+	lastSuccessfulHeartbeat time.Time
 }
 
 func NewHeartbeatManager(client *redis_client.Client, allocatedGPUs []int, user string) *HeartbeatManager {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &HeartbeatManager{
-		client:        client,
-		allocatedGPUs: allocatedGPUs,
-		user:          user,
-		ctx:           ctx,
-		cancel:        cancel,
-		done:          make(chan struct{}),
+		client:                  client,
+		allocatedGPUs:           allocatedGPUs,
+		user:                    user,
+		ctx:                     ctx,
+		cancel:                  cancel,
+		done:                    make(chan struct{}),
+		reservationLost:         make(chan struct{}),
+		lastSuccessfulHeartbeat: time.Now(),
 	}
 }
 
@@ -42,6 +51,8 @@ func (hm *HeartbeatManager) Start() error {
 	if err := hm.sendHeartbeat(); err != nil {
 		return fmt.Errorf("failed to send initial heartbeat: %w", err)
 	}
+
+	hm.lastSuccessfulHeartbeat = time.Now()
 
 	// Now start background tasks
 	go hm.heartbeatLoop()
@@ -58,6 +69,18 @@ func (hm *HeartbeatManager) Stop() {
 // Wait blocks until the heartbeat manager is stopped
 func (hm *HeartbeatManager) Wait() {
 	<-hm.done
+}
+
+// ReservationLost returns a channel that is closed when the reservation is
+// irrecoverably lost (taken by another user or cleaned up due to stale heartbeat).
+func (hm *HeartbeatManager) ReservationLost() <-chan struct{} {
+	return hm.reservationLost
+}
+
+func (hm *HeartbeatManager) signalReservationLost() {
+	hm.reservationLostOnce.Do(func() {
+		close(hm.reservationLost)
+	})
 }
 
 // heartbeatLoop sends periodic heartbeats with connection health checking
@@ -86,12 +109,26 @@ func (hm *HeartbeatManager) heartbeatLoop() {
 		case <-ticker.C:
 			if err := hm.sendHeartbeat(); err != nil {
 				hm.consecutiveFailures++
+
+				if errors.Is(err, ErrReservationLost) {
+					fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+					hm.signalReservationLost()
+					return
+				}
+
 				fmt.Fprintf(os.Stderr, "ERROR: Failed to send heartbeat (attempt %d): %v\n",
 					hm.consecutiveFailures, err)
 
 				// Try to recover by reconnecting if we've had multiple failures
 				if hm.consecutiveFailures >= maxFailuresBeforeReconnect {
 					hm.attemptReconnect()
+				}
+
+				if time.Since(hm.lastSuccessfulHeartbeat) >= types.HeartbeatTimeout {
+					fmt.Fprintf(os.Stderr, "ERROR: No successful heartbeat for %s, reservation is lost\n",
+						types.HeartbeatTimeout)
+					hm.signalReservationLost()
+					return
 				}
 
 				fmt.Fprintf(os.Stderr, "GPU reservations may be at risk of expiring!\n")
@@ -101,6 +138,7 @@ func (hm *HeartbeatManager) heartbeatLoop() {
 						hm.consecutiveFailures)
 				}
 				hm.consecutiveFailures = 0
+				hm.lastSuccessfulHeartbeat = time.Now()
 			}
 		}
 	}
@@ -141,13 +179,9 @@ func (hm *HeartbeatManager) sendHeartbeat() error {
 			if err := hm.client.SetGPUState(hm.ctx, gpuID, state); err != nil {
 				return fmt.Errorf("failed to update heartbeat for GPU %d: %v", gpuID, err)
 			}
-		} else if state.User != "" {
-			// GPU is reserved by someone else - this is expected, skip silently
-			continue
 		} else {
-			// GPU should be reserved by us but isn't - this is a problem!
-			return fmt.Errorf("GPU %d reservation lost: expected user=%s, type=%s but found user=%s, type=%s",
-				gpuID, hm.user, types.ReservationTypeRun, state.User, state.Type)
+			return fmt.Errorf("%w: GPU %d expected user=%s type=%s, found user=%q type=%q",
+				ErrReservationLost, gpuID, hm.user, types.ReservationTypeRun, state.User, state.Type)
 		}
 	}
 

--- a/internal/gpu/heartbeat_test.go
+++ b/internal/gpu/heartbeat_test.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ func TestHeartbeatManager_Structure(t *testing.T) {
 	assert.NotNil(t, manager.ctx)
 	assert.NotNil(t, manager.cancel)
 	assert.NotNil(t, manager.done)
+	assert.NotNil(t, manager.reservationLost)
 }
 
 func TestHeartbeatManager_StartStop(t *testing.T) {
@@ -351,7 +353,7 @@ func TestHeartbeatManager_ReservationLoss(t *testing.T) {
 
 	if err != nil {
 		t.Logf("✅ Heartbeat correctly detected reservation loss: %v", err)
-		assert.Contains(t, err.Error(), "reservation lost")
+		assert.True(t, errors.Is(err, ErrReservationLost))
 	} else {
 		t.Error("❌ Heartbeat should have detected reservation loss but didn't return error")
 	}


### PR DESCRIPTION
## Summary

- When the heartbeat supervisor detects that a GPU reservation has been irrecoverably lost (cleaned up due to stale heartbeat, or taken by another user), it now terminates the monitored process instead of letting it continue running as UNRESERVED
- Added `ErrReservationLost` sentinel error and `ReservationLost()` channel to `HeartbeatManager` so the supervisor can react immediately when reservations are lost
- Fixed a bug where `sendHeartbeat` silently skipped GPUs reserved by another user instead of treating it as a reservation loss

## Test plan

- [ ] `go vet ./...` passes
- [ ] `make test-short` passes
- [ ] Manual test: reserve a GPU with `chg run`, manually delete the Redis key (`redis-cli del canhazgpu:gpu:0`), verify the process gets SIGINT then SIGKILL after 30s grace period
- [ ] Manual test: reserve a GPU, stop Redis, wait >5 minutes, verify the process is killed after the heartbeat timeout is exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)